### PR TITLE
Template checks and readme additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ A function will be called with the following signature: `window.recaptcha_callba
 
 This function will need to be defined at the global scope (on the window object). The response object passed into the function will contain a score key with a value between one and zero. Use this value to determine how to modify your website.
 
+## Configuration
+
+Settings may be optionally configured using a config file.
+
+Create config/craft-recaptcha-3
+```php
+<?php
+return [
+	"siteKey" => getenv("GOOGLE_SITEKEY"),
+	"secretKey" => getenv("GOOGLE_SECRETKEY")
+];
+```
+and then move your keys in your env.
+
 ## Craft reCAPTCHA 3 Roadmap
 
 Some things to do, and ideas for potential features:

--- a/src/templates/frontend.twig
+++ b/src/templates/frontend.twig
@@ -1,7 +1,11 @@
 {% set siteKey = plugin('craft-recaptcha-3').settings.siteKey %}
 {% if siteKey is empty %}
-  The site key was not set for the Craft Recaptcha 3 plugin.
-  <a href="/admin/settings/plugins/craft-recaptcha-3" target="_blank">Please visit the settings page to add this key.</a>
+  {% if currentUser %}
+    The site key was not set for the Craft Recaptcha 3 plugin.
+    <a href="/{{ craft.app.config.general.cpTrigger }}/settings/plugins/craft-recaptcha-3" target="_blank">Please visit the settings page to add this key.</a>
+  {% else %}
+    <script>console.log("The site key was not set for the Craft Recaptcha 3 plugin.");</script>
+  {% endif %}
 {% else %}
   {% set action = action|default('contact') %}
 

--- a/src/templates/frontend.twig
+++ b/src/templates/frontend.twig
@@ -4,7 +4,7 @@
     The site key was not set for the Craft Recaptcha 3 plugin.
     <a href="/{{ craft.app.config.general.cpTrigger }}/settings/plugins/craft-recaptcha-3" target="_blank">Please visit the settings page to add this key.</a>
   {% else %}
-    <script>console.log("The site key was not set for the Craft Recaptcha 3 plugin.");</script>
+    <script>console.error("The site key was not set for the Craft Recaptcha 3 plugin.");</script>
   {% endif %}
 {% else %}
   {% set action = action|default('contact') %}


### PR DESCRIPTION
- checks if user is logged in before letting user know
  site/secret has not been set. This keeps the error
  from potentially destroying a layout.
- includes cpTrigger check for error message.
- updates readme.md with config instructions which
  resolve issue #10 without any code changes.